### PR TITLE
Extract mapped places from <Beskrivning> 

### DIFF
--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -343,8 +343,23 @@ class CypernImage:
         place_as_wikitext = ""
 
         if not place_string:
-            self.data["depicted_place"] = ""
-            return
+            place_matches = []
+            for place in places_mapping:
+                if place.lower() in desc_string.lower():
+                    if places_mapping[place]["wikidata"]:
+                        place_matches.append("{{{{city|1={wikidata}}}}}".format(
+                                wikidata=places_mapping[place]["wikidata"]))
+                    else:
+                        place_matches.append(place)
+
+                    # Don't forget to add the commons categories if present.
+                    if places_mapping[place].get('commonscat'):
+                        self.content_cats.append(places_mapping[place]["commonscat"])
+
+            if len(place_matches) == 0:
+                self.meta_cats.append("Media_contributed_by_SMVK_without_mapped_place_value")
+            else:
+                place_as_wikitext = "/".join(place_matches)
 
         if place_string in places_mapping:
             if place_string == "Stockholm":
@@ -360,40 +375,21 @@ class CypernImage:
                 place_as_wikitext = "Macheras"
 
             elif places_mapping[place_string]["wikidata"]:
-                place_as_wikitext = "{{{{city|1={wikidata}}}}}".format(
+                place_as_wikitext += "{{{{city|1={wikidata}}}}}".format(
                     wikidata=places_mapping[place_string]["wikidata"]
                 )
 
             else:
-                self.meta_cats.append("Media_contributed_by_SMVK_without_mapped_place_value")
-                place_as_wikitext = place_string
+                place_as_wikitext += place_string
 
             # Don't forget to add the commons categories, even though only wikidata is used in depicted people field
             if places_mapping[place_string].get('commonscat'):
                 self.content_cats.append(places_mapping[place_string]["commonscat"])
 
         else:
-            for place in places_mapping:
-                if place.lower() in desc_string.lower():
-
-                    if places_mapping[place]["wikidata"]:
-                        place_as_wikitext = "{{{{city|1={wikidata}}}}}".format(
-                            wikidata=places_mapping[place]["wikidata"]
-                            )
-
-                    else:
-                        place_as_wikitext = place
-
-                    # Don't forget to add the commons categories if present.
-                    if places_mapping[place].get('commonscat'):
-                        self.content_cats.append(places_mapping[place]["commonscat"])
-
-                else:
-                    self.meta_cats.append("Media_contributed_by_SMVK_without_mapped_place_value")
-                    # TODO: Handle images without depicted place value
+            place_as_wikitext += place_string
 
         self.data["depicted_place"] = place_as_wikitext
-        return place_as_wikitext
 
 
 if __name__ == '__main__':

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -342,26 +342,7 @@ class CypernImage:
         """
         place_as_wikitext = ""
 
-        if not place_string:
-            place_matches = []
-            for place in places_mapping:
-                if place.lower() in desc_string.lower():
-                    if places_mapping[place]["wikidata"]:
-                        place_matches.append("{{{{city|1={wikidata}}}}}".format(
-                                wikidata=places_mapping[place]["wikidata"]))
-                    else:
-                        place_matches.append(place)
-
-                    # Don't forget to add the commons categories if present.
-                    if places_mapping[place].get('commonscat'):
-                        self.content_cats.append(places_mapping[place]["commonscat"])
-
-            if len(place_matches) == 0:
-                self.meta_cats.append("Media_contributed_by_SMVK_without_mapped_place_value")
-            else:
-                place_as_wikitext = "/".join(place_matches)
-
-        if place_string in places_mapping:
+        if place_string and place_string in places_mapping:
             if place_string == "Stockholm":
                 # Mainly interiors from buildings gardens
                 self.meta_cats.append("Media_contributed_by_SMVK_without_mapped_place_value")
@@ -387,7 +368,23 @@ class CypernImage:
                 self.content_cats.append(places_mapping[place_string]["commonscat"])
 
         else:
-            place_as_wikitext += place_string
+            place_matches = []
+            for place in places_mapping:
+                if place.lower() in desc_string.lower():
+                    if places_mapping[place]["wikidata"]:
+                        place_matches.append("{{{{city|1={wikidata}}}}}".format(
+                            wikidata=places_mapping[place]["wikidata"]))
+                    else:
+                        place_matches.append(place)
+
+                    # Don't forget to add the commons categories if present.
+                    if places_mapping[place].get('commonscat'):
+                        self.content_cats.append(places_mapping[place]["commonscat"])
+
+            if len(place_matches) == 0:
+                self.meta_cats.append("Media_contributed_by_SMVK_without_mapped_place_value")
+            else:
+                place_as_wikitext = "/".join(place_matches)
 
         self.data["depicted_place"] = place_as_wikitext
 

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -30,8 +30,7 @@ def load_places_mapping():
     places_df = places_df.set_index("Nyckelord")
     places_df.columns = ["freq", "commonscat", "wikidata"]
 
-    places_df.replace("-", np.nan)
-    #places_df[places_df["commonscat"] == "-"] = np.nan
+    places_df[places_df == "-"] = None
 
     places_dict = {}
     for index, row in places_df.iterrows():
@@ -381,11 +380,9 @@ class CypernImage:
                     if places_mapping[place]["wikidata"]:
                         place_matches.append("{{{{city|1={wikidata}}}}}".format(
                             wikidata=places_mapping[place]["wikidata"]))
-                    else:
-                        place_matches.append(place)
 
                     # Don't forget to add the commons categories if present.
-                    if not places_mapping[place]["commonscat"] == np.nan:
+                    elif places_mapping[place].get('commonscat'):
                         self.content_cats.append(places_mapping[place]["commonscat"])
 
             if len(place_matches) == 0:

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -239,7 +239,7 @@ class CypernImage:
 
     def __init__(self):
         """Instantiate a single instance of a processed image."""
-        self.idno = None
+        self.idno = None  # <Fotonummer> in metadata, used as unique identifier i filename
         self.content_cats = []  # content cateogories without 'Category:'-prefix
         self.meta_cats = []  # maintance categories without 'Category:'-prefix
         self.data = {}  # dictionary holding individual field values as wikitext
@@ -364,8 +364,12 @@ class CypernImage:
                     place_as_wikitext += "{{{{city|1={wikidata}}}}}".format(
                         wikidata=places_mapping[place_string]["wikidata"]
                         )
+
+                else:
+                    place_as_wikitext += place_string
+
                 # Don't forget to add the commons categories, even though only wikidata is used in depicted people field
-                elif places_mapping[place_string].get('commonscat'):
+                if places_mapping[place_string].get('commonscat'):
                     self.content_cats.append(places_mapping[place_string]["commonscat"])
 
             else:
@@ -373,28 +377,27 @@ class CypernImage:
 
         else:
             place_matches = []
-            place_cnt = 0
             for place in places_mapping:
                 if place.lower() in desc_string.lower():
-                    place_cnt += 1
-                    if places_mapping[place]["wikidata"]:
-                        place_matches.append("{{{{city|1={wikidata}}}}}".format(
-                            wikidata=places_mapping[place]["wikidata"]))
+                    place_matches.append(place)
 
-                    # Don't forget to add the commons categories if present.
-                    elif places_mapping[place].get('commonscat'):
-                        self.content_cats.append(places_mapping[place]["commonscat"])
+            if len(place_matches) == 1:
+                if places_mapping[place]["wikidata"]:
+                    place_matches.append("{{{{city|1={wikidata}}}}}".format(
+                        wikidata=places_mapping[place]["wikidata"]))
+                else:
+                    place_as_wikitext = place
 
-            if len(place_matches) == 0:
-                self.meta_cats.append("Media_contributed_by_SMVK_without_mapped_place_value")
-            elif len(place_matches) >=2:
-                print("Found {} places in description! -> {} img: {}".format(
-                    len(place_matches),
-                    place_matches,
-                    self.idno))
-                print("places_mapping: {} idno: {}".format(places_mapping, self.idno))
+                # Don't forget to add the commons categories if present.
+                if places_mapping[place].get('commonscat'):
+                    self.content_cats.append(places_mapping[place]["commonscat"])
+
             else:
-                place_as_wikitext = "/".join(place_matches)
+                self.meta_cats.append("Media_contributed_by_SMVK_without_mapped_place_value")
+                if len(place_matches) >=2:
+                    print("Found {} places in description! -> {} img: {}".format(
+                        len(place_matches), place_matches, self.idno))
+
 
         self.data["depicted_place"] = place_as_wikitext
 

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -20,7 +20,8 @@ people_mapping = json.loads(people_mapping_file.read())
 
 def load_places_mapping():
     """
-    Read wikitable html and return a dictionary
+    Read wikitable html into Pandas DataFrame, transform it and return a dictionary.
+    
     :return: dictionary
     """
     kw_maps_url = "https://commons.wikimedia.org/wiki/Commons:Medelhavsmuseet/batchUploads/Cypern_places"


### PR DESCRIPTION
Looks for mapped places in the field <Beskrivning> in addition to <Ort, foto>. 
Result: 121 additional content categories added that would not have been added otherwise.

Also fixes a found indentation error in master that caused content_cats to be added only in rare cases.

Task: https://phabricator.wikimedia.org/T161878