### PR TITLE
Enrich description field

### DIFF
--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -237,9 +237,6 @@ def generate_infobox_template(item, img, places_mapping):
                 final_description += "."
             infobox += final_description
 
-    if not item["Nyckelord"] == "" and not item["Nyckelord"] == "Svenska Cypernexpeditionen":
-        infobox += "<br /> ''Nyckelord:''\n" + item["Nyckelord"]
-
     infobox += "}}\n"
     infobox += "{{en|The Swedish Cyprus expedition 1927-1931}}"
     infobox += "\n"

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -171,17 +171,21 @@ def remove_svenska_cypernexpedition_from_description(description):
 
     return new_string
 
-def process_addition_of_region_to_description(description_str, region_str):
+def process_addition_of_region_to_description(description_str, region_str, country_str):
     """
     Add <Region, foto> to description string, except when it is already present, with some smartness.
     
     :param description_str: String representing the processed/enriched description incl. <Nyckelord>.
-    :param region_str: The field value from column <Region ,foto> in metadata.
+    :param region_str: String with the field value from column <Region ,foto> in metadata.
+    :param country_str: String with the field value from column <Land> in metadata. 
     :return: String with possibly enriched description.
     """
     newdesc = description_str
     if region_str != "":
         newdesc += "\nRegion: " + region_str
+        if country_str != "":
+            newdesc += ", " + country_str
+        newdesc += "\n"
 
     return newdesc
 
@@ -217,7 +221,8 @@ def generate_infobox_template(item, img, places_mapping):
         # step 1 in enrichment process
         description_with_region = process_addition_of_region_to_description(
             description,
-            item["Region, foto"]
+            item["Region, foto"],
+            item["Land, foto"]
         )
 
         # step 2 in enrichment process
@@ -234,6 +239,7 @@ def generate_infobox_template(item, img, places_mapping):
 
     if not item["Nyckelord"] == "" and not item["Nyckelord"] == "Svenska Cypernexpeditionen":
         infobox += "<br /> ''Nyckelord:''\n" + item["Nyckelord"]
+
     infobox += "}}\n"
     infobox += "{{en|The Swedish Cyprus expedition 1927-1931}}"
     infobox += "\n"

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -112,18 +112,6 @@ def create_smvk_mm_link(item):
     return smvk_link
 
 
-def remove_svenska_cypernexpedition_from_description(description):
-    """
-    Remove the string "Svenska Cypernexpeditionen" from description, since it's in all descriptions.
-    
-    :param description: string containg the field value for column <Beskrivning> plus potential enrichments.
-    :return: String with "Svenska Cypernexpeditionen" removed.
-    """
-    new_string = re.sub(" Svenska Cypernexpeditionen\.?", "", description)
-
-    return new_string
-
-
 def generate_infobox_template(item, img, places_mapping):
     """Takes one item from metadata dictionary and constructs the infobox template.
     :param item: one metadata row for one photo
@@ -406,6 +394,18 @@ class CypernImage():
 
         self.data["Nyckelord"] = keywords_list
 
+    @staticmethod
+    def remove_svenska_cypernexpedition_from_description(description):
+        """
+        Remove the string "Svenska Cypernexpeditionen" from description, since it's in all descriptions.
+
+        :param description: string containg the field value for column <Beskrivning> plus potential enrichments.
+        :return: String with "Svenska Cypernexpeditionen" removed.
+        """
+        new_string = re.sub(" Svenska Cypernexpeditionen\.?", "", description)
+
+        return new_string
+
 
     def enrich_description_field(self, item):
         """
@@ -414,7 +414,7 @@ class CypernImage():
         :param item: dictionary containing metadata for one image.
         :return: string representing altered or unaltered description.
         """
-        description = remove_svenska_cypernexpedition_from_description(item["Beskrivning"])
+        description = self.remove_svenska_cypernexpedition_from_description(item["Beskrivning"])
 
         if not description.endswith("."):
             description += "."

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -135,7 +135,7 @@ def append_keywords_to_desc(description_str, kw_list):
     :return: string representing concatenation of old <Beskrivning> plus keywords list.
     """
     newdesc = description_str + "\n"
-    newdesc += "**Nyckelord:**\n"
+    newdesc += "'''Nyckelord:'''\n"
 
     for kw in kw_list:
         newdesc += kw + "\n"
@@ -182,7 +182,7 @@ def process_addition_of_region_to_description(description_str, region_str, count
     """
     newdesc = description_str
     if region_str != "":
-        newdesc += "\nRegion: " + region_str
+        newdesc += "\n'''Region:'''\n " + region_str
         if country_str != "":
             newdesc += ", " + country_str
         newdesc += "\n"

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -112,22 +112,6 @@ def create_smvk_mm_link(item):
     return smvk_link
 
 
-def append_keywords_to_desc(description_str, kw_list):
-    """
-    Append a list of keywords to the existing <Beskrivning> field value.
-
-    :param item: dictionary containing the metadata for an image.
-    :param kw_list: list of keywords found in column <Nyckelord>.
-    :return: string representing concatenation of old <Beskrivning> plus keywords list.
-    """
-    newdesc = description_str + "\n"
-    newdesc += "'''Nyckelord:'''\n"
-
-    for kw in kw_list:
-        newdesc += kw + "\n"
-    return newdesc
-
-
 def remove_svenska_cypernexpedition_from_description(description):
     """
     Remove the string "Svenska Cypernexpeditionen" from description, since it's in all descriptions.
@@ -481,11 +465,26 @@ class CypernImage():
         if self.data["Nyckelord"]:
             for kw in self.data["Nyckelord"]:
                 if not kw.lower() in description_str.lower():
-                    return append_keywords_to_desc(description_str, self.data["Nyckelord"])
+                    return self.append_keywords_to_desc(description_str, self.data["Nyckelord"])
                 else:
                     return description_str
         else:
             return description_str
+
+    def append_keywords_to_desc(self, description_str, kw_list):
+        """
+        Append a list of keywords to the existing <Beskrivning> field value.
+
+        :param item: dictionary containing the metadata for an image.
+        :param kw_list: list of keywords found in column <Nyckelord>.
+        :return: string representing concatenation of old <Beskrivning> plus keywords list.
+        """
+        newdesc = description_str + "\n"
+        newdesc += "'''Nyckelord:'''\n"
+
+        for kw in kw_list:
+            newdesc += kw + "\n"
+        return newdesc
 
 
 if __name__ == '__main__':

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -51,18 +51,12 @@ def create_commons_filename(metadata, fotonr):
     :param fotonr: string representing the <Fotonummer> field in the metadata
     :return: string
     """
-    if not metadata[fotonr]["Beskrivning"] == "":
-        enriched_description = enrich_description(metadata[fotonr])
-        cleaned_fname = helpers.format_filename(enriched_description,
-                                                "SMVK-MM-Cypern",
-                                                metadata[fotonr]["Fotonummer"]
-                                                )
-    else:
-        # TODO: handle images without description https://phabricator.wikimedia.org/T162274
-        cleaned_fname = helpers.format_filename("Svenska Cypernexpeditionen 1927-1931",
-                                                "SMVK-MM-Cypern",
-                                                metadata[fotonr]["Fotonummer"]
-                                                )
+    # TODO: handle images without description https://phabricator.wikimedia.org/T162274
+    enriched_description = enrich_description(metadata[fotonr])
+    cleaned_fname = helpers.format_filename(enriched_description,
+                                            "SMVK-MM-Cypern",
+                                            metadata[fotonr]["Fotonummer"]
+                                            )
 
     return cleaned_fname  # Assuming extension will be added på PrepUpload
 

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -422,7 +422,7 @@ class CypernImage():
         stripped_keywords = self.generate_list_of_stripped_keywords(item["Nyckelord"])
 
         # step 1 in enrichment process
-        description_with_region = self.process_addition_of_region_to_description(
+        description_with_region = self.process_region_addition_to_description(
             description,
             item["Region, foto"],
             item["Land, foto"]
@@ -468,7 +468,7 @@ class CypernImage():
             newdesc += kw + ", "
         return newdesc.rstrip(", ")
 
-    def process_addition_of_region_to_description(self, description_str, region_str, country_str):
+    def process_region_addition_to_description(self, description_str, region_str, country_str):
         """
         Add <Region, foto> to description string, except when it is already present, with some smartness.
 

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -122,7 +122,9 @@ def generate_infobox_template(item, img, places_mapping):
     # run CypernImage processing
     img.process_depicted_people(item["Personnamn / avbildad"])
     img.process_depicted_place(item["Ort, foto"], places_mapping)
+    img.generate_list_of_stripped_keywords(item["Nyckelord"])
     img.enrich_description_field(item)
+
 
     infobox = ""
     infobox += "{{Photograph \n"
@@ -419,8 +421,6 @@ class CypernImage():
         if not description.endswith("."):
             description += "."
 
-        stripped_keywords = self.generate_list_of_stripped_keywords(item["Nyckelord"])
-
         # step 1 in enrichment process
         description_with_region = self.process_region_addition_to_description(
             description,
@@ -433,7 +433,11 @@ class CypernImage():
             description_with_region
         )
 
-        self.data["enriched_description"] = description_with_keywords
+        # Step 3 in enrichment process
+        batch_description = " Svenska Cypernexpeditionen 1927-1931."
+        full_description = description_with_keywords + batch_description
+
+        self.data["enriched_description"] = full_description
 
     def process_keyword_addition_to_description(self, description_str):
         """

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -434,8 +434,9 @@ class CypernImage():
         )
 
         # Step 3 in enrichment process
-        batch_description = " Svenska Cypernexpeditionen 1927-1931."
-        full_description = description_with_keywords + batch_description
+
+        batch_description = ". Svenska Cypernexpeditionen 1927-1931."
+        full_description = description_with_keywords.rstrip(".") + batch_description
 
         self.data["enriched_description"] = full_description
 
@@ -465,8 +466,8 @@ class CypernImage():
         :param kw_list: list of keywords found in column <Nyckelord>.
         :return: string representing concatenation of old <Beskrivning> plus keywords list.
         """
-        newdesc = description_str + "\n"
-        newdesc += "''Nyckelord:'' "
+        newdesc = description_str
+        newdesc += " ''Nyckelord:'' "
 
         for kw in kw_list:
             newdesc += kw + ", "
@@ -482,11 +483,10 @@ class CypernImage():
         :return: String with possibly enriched description.
         """
         newdesc = description_str
-        if region_str != "":
-            newdesc += "\n'''Region:'''\n\n" + region_str
-            if country_str != "":
+        if region_str:
+            newdesc += " ''Region:'' " + region_str
+            if country_str:
                 newdesc += ", " + country_str
-            newdesc += "\n"
 
         return newdesc
 

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -128,24 +128,6 @@ def append_keywords_to_desc(description_str, kw_list):
     return newdesc
 
 
-def process_keyword_addition_to_description(description_str, keywords_list):
-    """
-    Append keywords to description, unless the only keyword is "Svenska Cypernexpeditionen". 
-    
-    :param fotonr: string representing the name of the image minus extension.
-    :param description_str: string respresenting the value of column <Beskrivning>.
-    :param keywords_str: string representing a comma-separated list of keywords.
-    :return: None (The altered description strings are returned in append_keywords_to_desc())
-    """
-    if keywords_list:
-        for kw in keywords_list:
-            if not kw.lower() in description_str.lower():
-                return  append_keywords_to_desc(description_str, keywords_list)
-            else:
-                return description_str
-    else:
-        return description_str
-
 def remove_svenska_cypernexpedition_from_description(description):
     """
     Remove the string "Svenska Cypernexpeditionen" from description, since it's in all descriptions.
@@ -458,6 +440,7 @@ class CypernImage():
 
         self.data["Nyckelord"] = keywords_list
 
+
     def enrich_description_field(self, item):
         """
         Try to add keywords and regional information to description.
@@ -480,12 +463,29 @@ class CypernImage():
         )
 
         # step 2 in enrichment process
-        description_with_keywords = process_keyword_addition_to_description(
-            description_with_region,
-            stripped_keywords
+        description_with_keywords = self.process_keyword_addition_to_description(
+            description_with_region
         )
 
         self.data["enriched_description"] = description_with_keywords
+
+    def process_keyword_addition_to_description(self, description_str):
+        """
+        Append keywords to description, unless the only keyword is "Svenska Cypernexpeditionen". 
+
+        :param fotonr: string representing the name of the image minus extension.
+        :param description_str: string respresenting the value of column <Beskrivning>.
+        :param keywords_str: string representing a comma-separated list of keywords.
+        :return: None (The altered description strings are returned in append_keywords_to_desc())
+        """
+        if self.data["Nyckelord"]:
+            for kw in self.data["Nyckelord"]:
+                if not kw.lower() in description_str.lower():
+                    return append_keywords_to_desc(description_str, self.data["Nyckelord"])
+                else:
+                    return description_str
+        else:
+            return description_str
 
 
 if __name__ == '__main__':

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -17,6 +17,7 @@ import numpy as np
 people_mapping_file = open("./people_mappings.json")
 people_mapping = json.loads(people_mapping_file.read())
 
+
 def load_places_mapping():
     """
     Read wikitable html and return a dictionary
@@ -52,13 +53,13 @@ def create_commons_filename(metadata, fotonr):
     :return: string
     """
     # TODO: handle images without description https://phabricator.wikimedia.org/T162274
-    #enriched_description = enrich_description_for_filename(metadata[fotonr])
-    #cleaned_fname = helpers.format_filename(enriched_description,
+    # enriched_description = enrich_description_for_filename(metadata[fotonr])
+    # cleaned_fname = helpers.format_filename(enriched_description,
     #                                        "SMVK-MM-Cypern",
     #                                        metadata[fotonr]["Fotonummer"]
     #                                        )
 
-    #return cleaned_fname  # Assuming extension will be added på PrepUpload
+    # return cleaned_fname  # Assuming extension will be added på PrepUpload
     pass
 
 
@@ -124,7 +125,6 @@ def generate_infobox_template(item, img, places_mapping):
     img.process_depicted_place(item["Ort, foto"], places_mapping)
     img.generate_list_of_stripped_keywords(item["Nyckelord"])
     img.enrich_description_field(item)
-
 
     infobox = ""
     infobox += "{{Photograph \n"
@@ -213,10 +213,8 @@ def main():
     for fotonr in metadata:
         img_info = {}
 
-        full_infotext = ""
-
         commons_filename = create_commons_filename(metadata, fotonr)
-        #print("New filename: {}".format(commons_filename))
+
         img_info["filename"] = commons_filename
 
         img = CypernImage()
@@ -227,13 +225,13 @@ def main():
 
         img_info["meta_cats"] = img.meta_cats
 
-        #print(infobox + "\n--------------\n")
         batch_info[fotonr] = img_info
 
     outfile.write(json.dumps(batch_info, ensure_ascii=False, indent=4))
     outfile.close()
 
-class CypernImage():
+
+class CypernImage:
     """Process the information for a single image."""
 
     def __init__(self):
@@ -246,7 +244,6 @@ class CypernImage():
                       "Media_contributed_by_SMVK_2017-02"]
 
         self.meta_cats.extend(batch_cats)
-
 
     def process_depicted_people(self, names_string):
         """
@@ -271,8 +268,6 @@ class CypernImage():
             wikitext_names.append(self.select_best_mapping_for_depicted_person(name))
 
         self.data["depicted_people"] = "/".join(wikitext_names)
-
-
 
     @staticmethod
     def isolate_name(names_string):
@@ -334,7 +329,6 @@ class CypernImage():
 
         return name_as_wikitext
 
-
     def process_depicted_place(self, place_string, places_mapping):
         """
         Create wikiformat depicted place string from raw input data.
@@ -380,7 +374,6 @@ class CypernImage():
             self.meta_cats.append("Media_contributed_by_SMVK_without_mapped_place_value")
             place_as_wikitext = place_string
 
-
         self.data["depicted_place"] = place_as_wikitext
 
     def generate_list_of_stripped_keywords(self, keyword_string):
@@ -407,7 +400,6 @@ class CypernImage():
         new_string = re.sub(" Svenska Cypernexpeditionen\.?", "", description)
 
         return new_string
-
 
     def enrich_description_field(self, item):
         """
@@ -444,10 +436,8 @@ class CypernImage():
         """
         Append keywords to description, unless the only keyword is "Svenska Cypernexpeditionen". 
 
-        :param fotonr: string representing the name of the image minus extension.
         :param description_str: string respresenting the value of column <Beskrivning>.
-        :param keywords_str: string representing a comma-separated list of keywords.
-        :return: None (The altered description strings are returned in append_keywords_to_desc())
+        :return: string with added keywords, if existing 
         """
         if self.data["Nyckelord"]:
             for kw in self.data["Nyckelord"]:
@@ -458,12 +448,13 @@ class CypernImage():
         else:
             return description_str
 
-    def append_keywords_to_desc(self, description_str, kw_list):
+    @staticmethod
+    def append_keywords_to_desc(description_str, kw_list):
         """
         Append a list of keywords to the existing <Beskrivning> field value.
 
-        :param item: dictionary containing the metadata for an image.
-        :param kw_list: list of keywords found in column <Nyckelord>.
+        :param description_str: string representing column <Beskrivning> in metadata.
+        :param kw_list: preprocessed list of keywords found in column <Nyckelord>.
         :return: string representing concatenation of old <Beskrivning> plus keywords list.
         """
         newdesc = description_str
@@ -473,7 +464,8 @@ class CypernImage():
             newdesc += kw + ", "
         return newdesc.rstrip(", ")
 
-    def process_region_addition_to_description(self, description_str, region_str, country_str):
+    @staticmethod
+    def process_region_addition_to_description(description_str, region_str, country_str):
         """
         Add <Region, foto> to description string, except when it is already present, with some smartness.
 

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -123,24 +123,6 @@ def remove_svenska_cypernexpedition_from_description(description):
 
     return new_string
 
-def process_addition_of_region_to_description(description_str, region_str, country_str):
-    """
-    Add <Region, foto> to description string, except when it is already present, with some smartness.
-    
-    :param description_str: String representing the processed/enriched description incl. <Nyckelord>.
-    :param region_str: String with the field value from column <Region ,foto> in metadata.
-    :param country_str: String with the field value from column <Land> in metadata. 
-    :return: String with possibly enriched description.
-    """
-    newdesc = description_str
-    if region_str != "":
-        newdesc += "\n'''Region:'''\n\n" + region_str
-        if country_str != "":
-            newdesc += ", " + country_str
-        newdesc += "\n"
-
-    return newdesc
-
 
 def generate_infobox_template(item, img, places_mapping):
     """Takes one item from metadata dictionary and constructs the infobox template.
@@ -440,7 +422,7 @@ class CypernImage():
         stripped_keywords = self.generate_list_of_stripped_keywords(item["Nyckelord"])
 
         # step 1 in enrichment process
-        description_with_region = process_addition_of_region_to_description(
+        description_with_region = self.process_addition_of_region_to_description(
             description,
             item["Region, foto"],
             item["Land, foto"]
@@ -485,6 +467,24 @@ class CypernImage():
         for kw in kw_list:
             newdesc += kw + ", "
         return newdesc.rstrip(", ")
+
+    def process_addition_of_region_to_description(self, description_str, region_str, country_str):
+        """
+        Add <Region, foto> to description string, except when it is already present, with some smartness.
+
+        :param description_str: String representing the processed/enriched description incl. <Nyckelord>.
+        :param region_str: String with the field value from column <Region ,foto> in metadata.
+        :param country_str: String with the field value from column <Land> in metadata. 
+        :return: String with possibly enriched description.
+        """
+        newdesc = description_str
+        if region_str != "":
+            newdesc += "\n'''Region:'''\n\n" + region_str
+            if country_str != "":
+                newdesc += ", " + country_str
+            newdesc += "\n"
+
+        return newdesc
 
 
 if __name__ == '__main__':

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -142,7 +142,7 @@ def append_keywords_to_desc(description_str, kw_list):
     return newdesc
 
 
-def process_keyword_addition_to_description(fotonr, description_str, keywords_list):
+def process_keyword_addition_to_description(description_str, keywords_list):
     """
     Append keywords to description, unless the only keyword is "Svenska Cypernexpeditionen". 
     
@@ -222,7 +222,6 @@ def generate_infobox_template(item, img, places_mapping):
 
         # step 2 in enrichment process
         description_with_keywords = process_keyword_addition_to_description(
-            item["Fotonummer"],
             description_with_region,
             stripped_keywords
             )

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -480,11 +480,11 @@ class CypernImage():
         :return: string representing concatenation of old <Beskrivning> plus keywords list.
         """
         newdesc = description_str + "\n"
-        newdesc += "'''Nyckelord:'''\n"
+        newdesc += "''Nyckelord:'' "
 
         for kw in kw_list:
-            newdesc += kw + "\n"
-        return newdesc
+            newdesc += kw + ", "
+        return newdesc.rstrip(", ")
 
 
 if __name__ == '__main__':

--- a/create_infotexts.py
+++ b/create_infotexts.py
@@ -182,7 +182,7 @@ def process_addition_of_region_to_description(description_str, region_str, count
     """
     newdesc = description_str
     if region_str != "":
-        newdesc += "\n'''Region:'''\n " + region_str
+        newdesc += "\n'''Region:'''\n\n" + region_str
         if country_str != "":
             newdesc += ", " + country_str
         newdesc += "\n"
@@ -216,6 +216,9 @@ def generate_infobox_template(item, img, places_mapping):
     if not item["Beskrivning"] == "":
         description = remove_svenska_cypernexpedition_from_description(item["Beskrivning"])
 
+        if not description.endswith("."):
+            description += "."
+
         stripped_keywords = generate_list_of_stripped_keywords(item["Nyckelord"])
 
         # step 1 in enrichment process
@@ -231,11 +234,10 @@ def generate_infobox_template(item, img, places_mapping):
             stripped_keywords
             )
 
-        if description_with_keywords:
-            final_description = description_with_keywords
-            if not final_description.endswith("."):
-                final_description += "."
-            infobox += final_description
+        infobox += description_with_keywords
+    else:
+        # TODO: Handle images with no description https://phabricator.wikimedia.org/T162274
+        pass
 
     infobox += "}}\n"
     infobox += "{{en|The Swedish Cyprus expedition 1927-1931}}"


### PR DESCRIPTION
In [PR 20](https://github.com/mattiasostmar/SMVK-Cypern_2017-01/pull/20) the code review included a comment that too similar filenames and descriptions are created. Thus the descriptions needs to be enriched.

This branch focuses on the enrichment of the description field and the prior data transformation of <Nyckelord>, <Region, foto> and <Land, foto>.

A separate branch will be created for the creation of filenames, based on the same data.

After analyzing the metadata I decided that <Nyckelord> and <Region, foto> together with <Land, foto> could be used to enrich the descriptions.

Task: https://phabricator.wikimedia.org/T158945

